### PR TITLE
Update spec and repo info to point to Media WG

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+All documentation, code and communication under this repository are covered by the [W3C Code of Ethics and Professional Conduct](https://www.w3.org/Consortium/cepc/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,23 +1,25 @@
-# Web Platform Incubator Community Group
+# Contributing
 
-This repository is being used for work in the Web Platform Incubator Community Group, governed by the [W3C Community License 
-Agreement (CLA)](http://www.w3.org/community/about/agreements/cla/). To contribute, you must join 
-the CG. 
+Contributions to this repository are intended to become part of Recommendation-track documents
+governed by the [W3C Patent Policy](http://www.w3.org/Consortium/Patent-Policy-20040205/) and
+[Software and Document License](http://www.w3.org/Consortium/Legal/copyright-software). To contribute, you must
+either participate in the relevant W3C Working Group or make a non-member patent licensing
+ commitment.
 
-If you are not the sole contributor to a contribution (pull request), please identify all 
+If you are not the sole contributor to a contribution (pull request), please identify all
 contributors in the pull request's body or in subsequent comments.
 
-To add a contributor (other than yourself, that's automatic), mark them one per line as follows:
+ To add a contributor (other than yourself, that's automatic), mark them one per line as follows:
 
-```
-+@github_username
-```
+ ```
+ +@github_username
+ ```
 
-If you added a contributor by mistake, you can remove them in a comment with:
+ If you added a contributor by mistake, you can remove them in a comment with:
 
-```
--@github_username
-```
+ ```
+ -@github_username
+ ```
 
-If you are making a pull request on behalf of someone else but you had no part in designing the 
-feature, you can remove yourself with the above syntax.
+ If you are making a pull request on behalf of someone else but you had no part in designing the
+ feature, you can remove yourself with the above syntax.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,2 @@
-All Reports in this Repository are licensed by Contributors under the 
-[W3C Software and Document
-License](http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document). Contributions to
-Specifications are made under the [W3C CLA](https://www.w3.org/community/about/agreements/cla/).
-
+All documents in this Repository are licensed by contributors under the [W3C
+Software and Document License](http://www.w3.org/Consortium/Legal/copyright-software).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# HTMLVideoElement Playback Quality
+# Media Playback Quality
 
-WICG repository for HTMLVideoElement extension for playback quality
+This repository contains the [Media Playback Quality](https://w3c.github.io/media-playback-quality/) specification, developed by the [Media Working Group](https://www.w3.org/media-wg/).
 
-This group is working on an improved version of `HTMLVideoELement.getVideoPlaybackQuality()` from the [MSE specification](https://w3c.github.io/media-source/#idl-def-VideoPlaybackQuality).
+The specification extends `HTMLVideoElement` to add new features that can be used to detect the user perceived playback quality, and was originally defined in the [Media Source Extensions specification](https://www.w3.org/TR/2016/REC-media-source-20161117/#VideoPlaybackQuality).

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     </script>
     <script class='remove'>
       var respecConfig = {
-        specStatus: 'CG-DRAFT',
+        specStatus: 'ED',
         shortName:  'media-playback-quality',
         editors: [
           {
@@ -19,10 +19,11 @@
         ],
         // previousMaturity: 'WD',
         // previousPublishDate: '2015-11-02',
-        wg: 'Web Incubator Community Group',
-        wgURI: 'https://wicg.io',
-        wgPatentURI: '',
-        github: 'wicg/media-playback-quality/',
+        wg: 'Media Working Group',
+        wgURI: 'https://www.w3.org/media-wg/',
+        wgPatentURI: 'https://www.w3.org/2004/01/pp-impl/115198/status',
+        wgPublicList: 'public-media-wg',
+        github: 'w3c/media-playback-quality/',
         xref: "web-platform",
       };
     </script>
@@ -36,8 +37,7 @@
 
     <section id='sotd'>
       <p>This document is extracted from the [[media-source]] specification in
-      order to work on the playback quality problematic in a larger scope. It is
-      a proposal for a <a href='https://www.w3.org/community/wicg/'>Web Incubator Community Group</a> specification.</p>
+      order to work on the playback quality problematic in a larger scope.</p>
     </section>
 
     <section>

--- a/w3c.json
+++ b/w3c.json
@@ -1,5 +1,5 @@
  {
-    "group":      ["80485"]
-,   "contacts":   ["marcoscaceres"]
-,   "shortName":  "media-playback-quality"
+    "group":      115198
+,   "contacts":   ["tidoust", "jernoble", "mounirlamouri"]
+,   "repo-type":  "rec-track"
 }


### PR DESCRIPTION
- Update spec boilerplate to note that the Media WG now works on the spec.
- Link to relevant W3C resources in repo files (license, contributing, w3c.json)
- Note new group and adjust MSE note in README

To be merged once the repo has been transferred to the W3C organization (#11)