### PR TITLE
Remove definitions/interface for corruptedFrames.

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,33 +62,13 @@
       been dropped. It MUST follow these rules:
         <ul>
           <li>It is initialized to 0 when the element is created.</li>
-          <li>It is reset to 0 when the 
+          <li>It is reset to 0 when the
             <a data-cite="html/media.html#media-element-load-algorithm">media element load algorithm</a> is
           invoked.</li>
           <li>It is incremented when a video frame is dropped predecode.</li>
           <li>It is incremented when a video frame is decoded but dropped because
           it missed a display deadline.</li>
         </ul>
-      </p>
-
-      <p>Each <a>HTMLVideoElement</a> MUST maintain a <dfn>corrupted video frame
-      count</dfn> variable keeping track of the total number of corrupted frames
-      detected. It MUST follow these rules:
-        <ul>
-          <li>It is initialized to 0 when the element is created.</li>
-          <li>It is reset to 0 when the 
-            <a data-cite="html/media.html#media-element-load-algorithm">media element load algorithm</a> is
-          invoked.</li>
-          <li>It is incremented when a corrupted video frame is detected by the
-          decoder.</li>
-        </ul>
-      </p>
-
-      <p>
-        It is up to the implementation to determine whether to display or drop a
-        corrupted frame. However, regardless of the choice made, the <a>total
-        video frame count</a> and <a>dropped video frame count</a> MUST be
-        updated appropriately.
       </p>
     </section>
 
@@ -113,8 +93,6 @@
           to the current value of the <a>total video frame count</a>.</li>
           <li>Set <var>playbackQuality</var>.<a>droppedVideoFrames</a>
           to the current value of the <a>dropped video frame count</a>.</li>
-          <li>Set <var>playbackQuality</var>.<a>corruptedVideoFrames</a>
-          to the current value of the <a>corrupted video frame count</a>.
           <li>Return <var>playbackQuality</var>.</li>
         </ol>
       </p>
@@ -127,7 +105,6 @@
         [Exposed=Window]
         interface VideoPlaybackQuality {
           readonly attribute DOMHighResTimeStamp creationTime;
-          readonly attribute unsigned long corruptedVideoFrames;
           readonly attribute unsigned long droppedVideoFrames;
           readonly attribute unsigned long totalVideoFrames;
         };
@@ -135,11 +112,6 @@
 
       <p>
         The <dfn>creationTime</dfn> attribute MUST return the <a>current high resolution time</a> for when object was created.
-      </p>
-
-      <p>
-        The <dfn>corruptedVideoFrames</dfn> attribute MUST
-        return the total number of corrupted frames that have been detected.
       </p>
 
       <p>


### PR DESCRIPTION
Media WG resolved to remove this field at TPAC.
https://www.w3.org/2019/09/19-mediawg-minutes.html#resolution01

Most UAs have not implemented corrupted frames and have no means to do
so.

Serious corruption will generally produce a decode error. This may
may not be logically associated with particular frames. Less serious
corruption may produce artifacts in the output, but in most cases it is
not feasible for a UA to know that this has occurred.