### PR TITLE
Remove corrupted frames from the spec.

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,32 +72,6 @@
           it missed a display deadline.</li>
         </ul>
       </p>
-
-      <p class='note'>
-        The following <a>corrupted video frame count</a> concept and associated
-        interfaces are deprecated. They may or may not be present in current
-        implementations.
-      </p>
-
-      <p>Each {{HTMLVideoElement}} MUST maintain a
-      <dfn>corrupted video frame count</dfn> variable keeping track of the total
-      number of corrupted frames detected. It MUST follow these rules:
-        <ul>
-          <li>It is initialized to 0 when the element is created.</li>
-          <li>It is reset to 0 when the
-            <a data-cite="html/media.html#media-element-load-algorithm">media element load algorithm</a> is
-          invoked.</li>
-          <li>It is incremented when a corrupted video frame is detected by the
-          decoder.</li>
-        </ul>
-      </p>
-
-      <p>
-        It is up to the implementation to determine whether to display or drop a
-        corrupted frame. However, regardless of the choice made, the <a>total
-        video frame count</a> and <a>dropped video frame count</a> MUST be
-        updated appropriately.
-      </p>
     </section>
 
     <section data-dfn-for="HTMLVideoElement">
@@ -121,9 +95,6 @@
           to the current value of the <a>total video frame count</a>.</li>
           <li>Set <var>playbackQuality</var>.<a>droppedVideoFrames</a>
           to the current value of the <a>dropped video frame count</a>.</li>
-          <li><b>[DEPRECATED]</b> Set
-          <var>playbackQuality</var>.<a>corruptedVideoFrames</a>
-          to the current value of the <a>corrupted video frame count</a>.
           <li>Return <var>playbackQuality</var>.</li>
         </ol>
       </p>
@@ -138,9 +109,6 @@
           readonly attribute DOMHighResTimeStamp creationTime;
           readonly attribute unsigned long droppedVideoFrames;
           readonly attribute unsigned long totalVideoFrames;
-
-          // Deprecated!
-          readonly attribute unsigned long corruptedVideoFrames;
         };
       </pre>
 
@@ -159,12 +127,6 @@
         The <dfn>totalVideoFrames</dfn> attribute MUST
         return the total number of frames that would have been displayed if no
         frames are dropped.
-      </p>
-
-      <p>
-        <b>[DEPRECATED]</b>
-        The <dfn data-lt="foo">corruptedVideoFrames</dfn> attribute MUST
-        return the total number of corrupted frames that have been detected.
       </p>
     </section>
     <section id='conformance'>


### PR DESCRIPTION
As the title suggests. Resolves https://github.com/w3c/media-playback-quality/issues/27.